### PR TITLE
splash screen at webapp launch

### DIFF
--- a/Source/ClientApp/package.json
+++ b/Source/ClientApp/package.json
@@ -35,6 +35,7 @@
         "react-query": "^3.39.1",
         "react-redux": "^8.0.2",
         "react-router-dom": "5.3.0",
+        "react-spinners": "^0.13.3",
         "recharts": "^2.1.12",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",

--- a/Source/ClientApp/pnpm-lock.yaml
+++ b/Source/ClientApp/pnpm-lock.yaml
@@ -50,6 +50,7 @@ specifiers:
   react-query: ^3.39.1
   react-redux: ^8.0.2
   react-router-dom: 5.3.0
+  react-spinners: ^0.13.3
   recharts: ^2.1.12
   redux: ^4.2.0
   redux-devtools-extension: ^2.13.9
@@ -88,6 +89,7 @@ dependencies:
   react-query: 3.39.1_sfoxds7t5ydpegc3knd667wn6m
   react-redux: 8.0.2_btibqj2va2udev2shascacmhb4
   react-router-dom: 5.3.0_react@17.0.2
+  react-spinners: 0.13.3_sfoxds7t5ydpegc3knd667wn6m
   recharts: 2.1.12_oxfzelaz5ynxsop2v2nu2h2m64
   redux: 4.2.0
   redux-thunk: 2.4.1_redux@4.2.0
@@ -6525,6 +6527,16 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-transition-group: 2.9.0_sfoxds7t5ydpegc3knd667wn6m
+    dev: false
+
+  /react-spinners/0.13.3_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-FHQMH6dAl1Vw4Lxv0H7hbGsjBs0aKNVwjGrDJLuD9R/C3h9+IuBhKJOJyCcegxMaLiBSBV96Tp+XV3OwPK8Vtw==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: false
 
   /react-transition-group/2.9.0_sfoxds7t5ydpegc3knd667wn6m:

--- a/Source/ClientApp/src/App.tsx
+++ b/Source/ClientApp/src/App.tsx
@@ -31,7 +31,7 @@ const App: React.FunctionComponent = () => {
     const [noConnectionModalVisible, setNoConnectionModalVisible] = React.useState(false);
     const [aboutModalVisible, setAboutModalVisible] = React.useState(false);
     const [initializedTime] = React.useState(moment());
-    // create 3 second timer and set appState.ready to true when it ends
+
     useInterval(
         () => {
             if (appState.appReady) return;

--- a/Source/ClientApp/src/App.tsx
+++ b/Source/ClientApp/src/App.tsx
@@ -28,17 +28,17 @@ const App: React.FunctionComponent = () => {
     const dispatch = useDispatch();
     const location = useLocation();
     const appState = useSelector<VitalState, AppState>(state => state.appState);
-    const [noConnectionModalVisible, setNoConnectionModalVisible] = React.useState(false);
+    const [noConnection, setNoConnection] = React.useState(false);
     const [aboutModalVisible, setAboutModalVisible] = React.useState(false);
     const [initializedTime] = React.useState(moment());
 
     useInterval(
         () => {
             if (appState.httpConnected && appState.signalRConnected) {
-                setNoConnectionModalVisible(false);
+                setNoConnection(false);
                 dispatch(updateAppReadyAction(true));
             } else if (moment().diff(initializedTime, "seconds") > 10) {
-                setNoConnectionModalVisible(true);
+                setNoConnection(true);
             }
         },
 
@@ -73,12 +73,12 @@ const App: React.FunctionComponent = () => {
     }
 
     // eslint-disable-next-line no-constant-condition
-    if (!appState.appReady) return <>{noConnectionModalVisible ? <ConnnectionIssuePage /> : <SplashScreen />}</>;
+    if (!appState.appReady) return <>{noConnection ? <ConnnectionIssuePage /> : <SplashScreen />}</>;
 
     return (
         <div id="page" style={{ display: "flex", flexDirection: "column", overflow: "hidden", height: "100vh", width: "100vw" }}>
             <Router>
-                <Modal visible={noConnectionModalVisible} centered footer={null} title={"Problem connecting to Vital Service"} width={600} onCancel={() => setNoConnectionModalVisible(false)}>
+                <Modal visible={noConnection} centered footer={null} title={"Problem connecting to Vital Service"} width={600} onCancel={() => setNoConnection(false)}>
                     <ConnnectionIssuePage />
                 </Modal>
                 <Modal visible={aboutModalVisible} centered footer={null} title={"Info"} width={500} onCancel={() => setAboutModalVisible(false)}>
@@ -108,7 +108,7 @@ const App: React.FunctionComponent = () => {
                         <GpuPerfBadge />
                         <span>
                             {!appState.httpConnected && (
-                                <span style={{ color: "orange", cursor: "pointer" }} onClick={() => setNoConnectionModalVisible(true)}>
+                                <span style={{ color: "orange", cursor: "pointer" }} onClick={() => setNoConnection(true)}>
                                     <WarningOutlined style={{ color: "orange" }} /> Disconnected
                                 </span>
                             )}

--- a/Source/ClientApp/src/App.tsx
+++ b/Source/ClientApp/src/App.tsx
@@ -34,9 +34,8 @@ const App: React.FunctionComponent = () => {
 
     useInterval(
         () => {
-            if (appState.appReady) return;
-
             if (appState.httpConnected && appState.signalRConnected) {
+                setNoConnectionModalVisible(false);
                 dispatch(updateAppReadyAction(true));
             } else if (moment().diff(initializedTime, "seconds") > 10) {
                 setNoConnectionModalVisible(true);

--- a/Source/ClientApp/src/pages/SpashScreen.tsx
+++ b/Source/ClientApp/src/pages/SpashScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { PulseLoader } from "react-spinners";
+
+export const SplashScreen: React.FunctionComponent = () => {
+    return (
+        <div id="page" style={{ display: "grid", overflow: "hidden", height: "100vh", width: "100vw", alignContent: "center", justifyContent: "center" }}>
+            <div style={{ fontSize: "3vh" }}>Booting</div>
+            <div style={{ display: "grid", justifyContent: "center" }}>
+                <div>
+                    <PulseLoader size={"3vh"} color={"purple"} />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/Source/ClientApp/src/pages/SpashScreen.tsx
+++ b/Source/ClientApp/src/pages/SpashScreen.tsx
@@ -7,7 +7,7 @@ export const SplashScreen: React.FunctionComponent = () => {
             <div style={{ fontSize: "3vh" }}>Booting</div>
             <div style={{ display: "grid", justifyContent: "center" }}>
                 <div>
-                    <PulseLoader size={"3vh"} color={"purple"} />
+                    <PulseLoader size={"3vh"} color={"white"} />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
* shows a splash screen at launch for 10 seconds before showing cannot connect page.
* Resolves #20 
don't show the process page until everything is connected. 
show the connection error page after 10 seconds if app cannot connect to backend service.
this also improves the experience where services are running already and user launches the client app. the original behavior was instantly showing not connected modal with content in the background. Now it will show the splash page for 1 second and then resume to show the app contents.



![Vital_Utilities_y6fTxEZLvd](https://user-images.githubusercontent.com/19627023/180578966-5118e78a-7f14-47bf-9fa7-92f37c621275.gif)
![Vital_Utilities_tWZQ3adarK](https://user-images.githubusercontent.com/19627023/180580259-fa7aab2f-7310-460a-bc36-d5bea7dfdca9.gif)
